### PR TITLE
fix(up, down, halfUp): fix handling of numbers close to 0 and roundin…

### DIFF
--- a/packages/core/src/divide/__tests__/down.test.ts
+++ b/packages/core/src/divide/__tests__/down.test.ts
@@ -4,6 +4,12 @@ import { down } from '../down';
 
 describe('down', () => {
   describe('decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(down(20, 10, calculator)).toBe(2);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(down(-20, 10, calculator)).toBe(-2);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(down(14, 10, calculator)).toBe(1);
     });
@@ -22,8 +28,41 @@ describe('down', () => {
     it('rounds down with a negative quotient above half', () => {
       expect(down(-16, 10, calculator)).toBe(-2);
     });
+    it('rounds to 0 with a positive quotient above half that is close to 0', () => {
+      expect(down(6, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with a positive half quotient that is close to 0', () => {
+      expect(down(5, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
+      expect(down(4, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(down(1, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(down(0, 10, calculator)).toBe(0);
+    });
+    it('rounds to -1 with amount 1 and a negative quotient below half that is close to 0', () => {
+      expect(down(-1, 10, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative quotient close to and below half, that is close to 0', () => {
+      expect(down(-4, 10, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative half quotient that is close to 0', () => {
+      expect(down(-5, 10, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
+      expect(down(-6, 10, calculator)).toBe(-1);
+    });
   });
   describe('non-decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(down(20, 5, calculator)).toBe(4);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(down(-20, 5, calculator)).toBe(-4);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(down(22, 5, calculator)).toBe(4);
     });
@@ -41,6 +80,27 @@ describe('down', () => {
     });
     it('rounds down with a negative quotient above half', () => {
       expect(down(-24, 5, calculator)).toBe(-5);
+    });
+    it('rounds to 0 with a positive quotient above half that is close to 0', () => {
+      expect(down(3, 5, calculator)).toBe(0);
+    });
+    it('rounds to 0 with a positive half quotient that is close to 0', () => {
+      expect(down(3, 6, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(down(1, 5, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(down(0, 5, calculator)).toBe(0);
+    });
+    it('rounds to -1 with amount -1 and a negative quotient below half that is close to 0', () => {
+      expect(down(-1, 5, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative half quotient that is close to 0', () => {
+      expect(down(-3, 6, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
+      expect(down(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfAwayFromZero.test.ts
+++ b/packages/core/src/divide/__tests__/halfAwayFromZero.test.ts
@@ -4,6 +4,12 @@ import { halfAwayFromZero } from '../halfAwayFromZero';
 
 describe('halfAwayFromZero', () => {
   describe('decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfAwayFromZero(20, 10, calculator)).toBe(2);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfAwayFromZero(-20, 10, calculator)).toBe(-2);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfAwayFromZero(14, 10, calculator)).toBe(1);
     });
@@ -22,8 +28,41 @@ describe('halfAwayFromZero', () => {
     it('rounds down with a negative quotient above half', () => {
       expect(halfAwayFromZero(-16, 10, calculator)).toBe(-2);
     });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfAwayFromZero(6, 10, calculator)).toBe(1);
+    });
+    it('rounds to 1 with a positive half quotient that is close to 0', () => {
+      expect(halfAwayFromZero(5, 10, calculator)).toBe(1);
+    });
+    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
+      expect(halfAwayFromZero(4, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfAwayFromZero(1, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfAwayFromZero(0, 10, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
+      expect(halfAwayFromZero(-1, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
+      expect(halfAwayFromZero(-4, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative half quotient that is close to 0', () => {
+      expect(halfAwayFromZero(-5, 10, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
+      expect(halfAwayFromZero(-6, 10, calculator)).toBe(-1);
+    });
   });
   describe('non-decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfAwayFromZero(20, 5, calculator)).toBe(4);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfAwayFromZero(-20, 5, calculator)).toBe(-4);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfAwayFromZero(22, 5, calculator)).toBe(4);
     });
@@ -41,6 +80,27 @@ describe('halfAwayFromZero', () => {
     });
     it('rounds down with a negative quotient above half', () => {
       expect(halfAwayFromZero(-24, 5, calculator)).toBe(-5);
+    });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfAwayFromZero(3, 5, calculator)).toBe(1);
+    });
+    it('rounds to 1 with a positive half quotient that is close to 0', () => {
+      expect(halfAwayFromZero(3, 6, calculator)).toBe(1);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfAwayFromZero(1, 5, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfAwayFromZero(0, 5, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
+      expect(halfAwayFromZero(-1, 5, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative half quotient that is close to 0', () => {
+      expect(halfAwayFromZero(-3, 6, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
+      expect(halfAwayFromZero(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfDown.test.ts
+++ b/packages/core/src/divide/__tests__/halfDown.test.ts
@@ -4,6 +4,12 @@ import { halfDown } from '../halfDown';
 
 describe('halfDown', () => {
   describe('decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfDown(20, 10, calculator)).toBe(2);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfDown(-20, 10, calculator)).toBe(-2);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfDown(14, 10, calculator)).toBe(1);
     });
@@ -22,8 +28,41 @@ describe('halfDown', () => {
     it('rounds down with a negative quotient above half', () => {
       expect(halfDown(-16, 10, calculator)).toBe(-2);
     });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfDown(6, 10, calculator)).toBe(1);
+    });
+    it('rounds to 0 with a positive half quotient that is close to 0', () => {
+      expect(halfDown(5, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
+      expect(halfDown(4, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfDown(1, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfDown(0, 10, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
+      expect(halfDown(-1, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
+      expect(halfDown(-4, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative half quotient that is close to 0', () => {
+      expect(halfDown(-5, 10, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
+      expect(halfDown(-6, 10, calculator)).toBe(-1);
+    });
   });
   describe('non-decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfDown(20, 5, calculator)).toBe(4);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfDown(-20, 5, calculator)).toBe(-4);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfDown(22, 5, calculator)).toBe(4);
     });
@@ -41,6 +80,27 @@ describe('halfDown', () => {
     });
     it('rounds down with a negative quotient above half', () => {
       expect(halfDown(-24, 5, calculator)).toBe(-5);
+    });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfDown(3, 5, calculator)).toBe(1);
+    });
+    it('rounds to 0 with a positive half quotient that is close to 0', () => {
+      expect(halfDown(3, 6, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfDown(1, 5, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfDown(0, 5, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
+      expect(halfDown(-1, 5, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative half quotient that is close to 0', () => {
+      expect(halfDown(-3, 6, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
+      expect(halfDown(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfEven.test.ts
+++ b/packages/core/src/divide/__tests__/halfEven.test.ts
@@ -4,6 +4,12 @@ import { halfEven } from '../halfEven';
 
 describe('halfEven', () => {
   describe('decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfEven(20, 10, calculator)).toBe(2);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfEven(-20, 10, calculator)).toBe(-2);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfEven(14, 10, calculator)).toBe(1);
     });
@@ -25,8 +31,41 @@ describe('halfEven', () => {
     it('rounds down with a negative quotient above half', () => {
       expect(halfEven(-16, 10, calculator)).toBe(-2);
     });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfEven(6, 10, calculator)).toBe(1);
+    });
+    it('rounds to 0 with a positive half quotient that is close to 0', () => {
+      expect(halfEven(5, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
+      expect(halfEven(4, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfEven(1, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfEven(0, 10, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
+      expect(halfEven(-1, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
+      expect(halfEven(-4, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative half quotient that is close to 0', () => {
+      expect(halfEven(-5, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
+      expect(halfEven(-6, 10, calculator)).toBe(-1);
+    });
   });
   describe('non-decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfEven(20, 5, calculator)).toBe(4);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfEven(-20, 5, calculator)).toBe(-4);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfEven(22, 5, calculator)).toBe(4);
     });
@@ -47,6 +86,27 @@ describe('halfEven', () => {
     });
     it('rounds down with a negative quotient above half', () => {
       expect(halfEven(-24, 5, calculator)).toBe(-5);
+    });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfEven(3, 5, calculator)).toBe(1);
+    });
+    it('rounds to 0 with a positive half quotient that is close to 0', () => {
+      expect(halfEven(3, 6, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfEven(1, 5, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfEven(0, 5, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
+      expect(halfEven(-1, 5, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative half quotient that is close to 0', () => {
+      expect(halfEven(-3, 6, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
+      expect(halfEven(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfOdd.test.ts
+++ b/packages/core/src/divide/__tests__/halfOdd.test.ts
@@ -4,6 +4,12 @@ import { halfOdd } from '../halfOdd';
 
 describe('halfOdd', () => {
   describe('decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfOdd(20, 10, calculator)).toBe(2);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfOdd(-20, 10, calculator)).toBe(-2);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfOdd(14, 10, calculator)).toBe(1);
     });
@@ -25,8 +31,41 @@ describe('halfOdd', () => {
     it('rounds down with a negative quotient above half', () => {
       expect(halfOdd(-16, 10, calculator)).toBe(-2);
     });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfOdd(6, 10, calculator)).toBe(1);
+    });
+    it('rounds to 1 with a positive half quotient that is close to 0', () => {
+      expect(halfOdd(5, 10, calculator)).toBe(1);
+    });
+    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
+      expect(halfOdd(4, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfOdd(1, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfOdd(0, 10, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
+      expect(halfOdd(-1, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
+      expect(halfOdd(-4, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative half quotient that is close to 0', () => {
+      expect(halfOdd(-5, 10, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
+      expect(halfOdd(-6, 10, calculator)).toBe(-1);
+    });
   });
   describe('non-decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfOdd(20, 5, calculator)).toBe(4);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfOdd(-20, 5, calculator)).toBe(-4);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfOdd(22, 5, calculator)).toBe(4);
     });
@@ -47,6 +86,27 @@ describe('halfOdd', () => {
     });
     it('rounds down with a negative quotient above half', () => {
       expect(halfOdd(-24, 5, calculator)).toBe(-5);
+    });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfOdd(3, 5, calculator)).toBe(1);
+    });
+    it('rounds to 1 with a positive half quotient that is close to 0', () => {
+      expect(halfOdd(3, 6, calculator)).toBe(1);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfOdd(1, 5, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfOdd(0, 5, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
+      expect(halfOdd(-1, 5, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative half quotient that is close to 0', () => {
+      expect(halfOdd(-3, 6, calculator)).toBe(-1);
+    });
+    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
+      expect(halfOdd(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfTowardsZero.test.ts
+++ b/packages/core/src/divide/__tests__/halfTowardsZero.test.ts
@@ -4,6 +4,12 @@ import { halfTowardsZero } from '../halfTowardsZero';
 
 describe('halfTowardsZero', () => {
   describe('decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfTowardsZero(20, 10, calculator)).toBe(2);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfTowardsZero(-20, 10, calculator)).toBe(-2);
+    });
     it('rounds down with a positive float below half', () => {
       expect(halfTowardsZero(14, 10, calculator)).toBe(1);
     });
@@ -22,8 +28,41 @@ describe('halfTowardsZero', () => {
     it('rounds down with a negative float above half', () => {
       expect(halfTowardsZero(-16, 10, calculator)).toBe(-2);
     });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfTowardsZero(6, 10, calculator)).toBe(1);
+    });
+    it('rounds to 0 with a positive half quotient that is close to 0', () => {
+      expect(halfTowardsZero(5, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
+      expect(halfTowardsZero(4, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfTowardsZero(1, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfTowardsZero(0, 10, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
+      expect(halfTowardsZero(-1, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
+      expect(halfTowardsZero(-4, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative half quotient that is close to 0', () => {
+      expect(halfTowardsZero(-5, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
+      expect(halfTowardsZero(-6, 10, calculator)).toBe(-1);
+    });
   });
   describe('non-decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfTowardsZero(20, 5, calculator)).toBe(4);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfTowardsZero(-20, 5, calculator)).toBe(-4);
+    });
     it('rounds down with a positive float below half', () => {
       expect(halfTowardsZero(22, 5, calculator)).toBe(4);
     });
@@ -41,6 +80,27 @@ describe('halfTowardsZero', () => {
     });
     it('rounds down with a negative float above half', () => {
       expect(halfTowardsZero(-24, 5, calculator)).toBe(-5);
+    });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfTowardsZero(3, 5, calculator)).toBe(1);
+    });
+    it('rounds to 0 with a positive half quotient that is close to 0', () => {
+      expect(halfTowardsZero(3, 6, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfTowardsZero(1, 5, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfTowardsZero(0, 5, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
+      expect(halfTowardsZero(-1, 5, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative half quotient that is close to 0', () => {
+      expect(halfTowardsZero(-3, 6, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
+      expect(halfTowardsZero(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/halfUp.test.ts
+++ b/packages/core/src/divide/__tests__/halfUp.test.ts
@@ -4,6 +4,12 @@ import { halfUp } from '../halfUp';
 
 describe('halfUp', () => {
   describe('decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfUp(20, 10, calculator)).toBe(2);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfUp(-20, 10, calculator)).toBe(-2);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfUp(14, 10, calculator)).toBe(1);
     });
@@ -22,8 +28,41 @@ describe('halfUp', () => {
     it('rounds down with a negative quotient above half', () => {
       expect(halfUp(-16, 10, calculator)).toBe(-2);
     });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfUp(6, 10, calculator)).toBe(1);
+    });
+    it('rounds to 1 with a positive half quotient that is close to 0', () => {
+      expect(halfUp(5, 10, calculator)).toBe(1);
+    });
+    it('rounds to 0 with a positive quotient and below half that is close to 0', () => {
+      expect(halfUp(4, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfUp(1, 10, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfUp(0, 10, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
+      expect(halfUp(-1, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
+      expect(halfUp(-4, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative half quotient that is close to 0', () => {
+      expect(halfUp(-5, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative quotient above half, that is close to 0', () => {
+      expect(halfUp(-6, 10, calculator)).toBe(-1);
+    });
   });
   describe('non-decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(halfUp(20, 5, calculator)).toBe(4);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(halfUp(-20, 5, calculator)).toBe(-4);
+    });
     it('rounds down with a positive quotient below half', () => {
       expect(halfUp(22, 5, calculator)).toBe(4);
     });
@@ -41,6 +80,27 @@ describe('halfUp', () => {
     });
     it('rounds down with a negative quotient above half', () => {
       expect(halfUp(-24, 5, calculator)).toBe(-5);
+    });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(halfUp(3, 5, calculator)).toBe(1);
+    });
+    it('rounds to 1 with a positive half quotient that is close to 0', () => {
+      expect(halfUp(3, 6, calculator)).toBe(1);
+    });
+    it('rounds to 0 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(halfUp(1, 5, calculator)).toBe(0);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(halfUp(0, 5, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
+      expect(halfUp(-1, 5, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative half quotient that is close to 0', () => {
+      expect(halfUp(-3, 6, calculator)).toBe(-0);
+    });
+    it('rounds to -1 with a negative quotient above half that is close to 0', () => {
+      expect(halfUp(-3, 5, calculator)).toBe(-1);
     });
   });
 });

--- a/packages/core/src/divide/__tests__/up.test.ts
+++ b/packages/core/src/divide/__tests__/up.test.ts
@@ -4,6 +4,12 @@ import { up } from '../up';
 
 describe('up', () => {
   describe('decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(up(20, 10, calculator)).toBe(2);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(up(-20, 10, calculator)).toBe(-2);
+    });
     it('rounds up with a positive quotient below half', () => {
       expect(up(14, 10, calculator)).toBe(2);
     });
@@ -22,8 +28,41 @@ describe('up', () => {
     it('rounds up with a negative quotient above half', () => {
       expect(up(-16, 10, calculator)).toBe(-1);
     });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(up(6, 10, calculator)).toBe(1);
+    });
+    it('rounds to 1 with a positive half quotient that is close to 0', () => {
+      expect(up(5, 10, calculator)).toBe(1);
+    });
+    it('rounds to 1 with a positive quotient and below half that is close to 0', () => {
+      expect(up(4, 10, calculator)).toBe(1);
+    });
+    it('rounds to 1 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(up(1, 10, calculator)).toBe(1);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(up(0, 10, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount 1 and a negative quotient below half that is close to 0', () => {
+      expect(up(-1, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative quotient close to and below half, that is close to 0', () => {
+      expect(up(-4, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative half quotient that is close to 0', () => {
+      expect(up(-5, 10, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative quotient above half, that is close to 0', () => {
+      expect(up(-6, 10, calculator)).toBe(-0);
+    });
   });
   describe('non-decimal factors', () => {
+    it('should not round positive integer quotients', () => {
+      expect(up(20, 5, calculator)).toBe(4);
+    });
+    it('should not round negative integer quotients', () => {
+      expect(up(-20, 5, calculator)).toBe(-4);
+    });
     it('rounds up with a positive quotient below half', () => {
       expect(up(22, 5, calculator)).toBe(5);
     });
@@ -41,6 +80,27 @@ describe('up', () => {
     });
     it('rounds up with a negative quotient above half', () => {
       expect(up(-24, 5, calculator)).toBe(-4);
+    });
+    it('rounds to 1 with a positive quotient above half that is close to 0', () => {
+      expect(up(3, 5, calculator)).toBe(1);
+    });
+    it('rounds to 1 with a positive half quotient that is close to 0', () => {
+      expect(up(3, 6, calculator)).toBe(1);
+    });
+    it('rounds to 1 with amount 1 and a positive quotient below half that is close to 0', () => {
+      expect(up(1, 5, calculator)).toBe(1);
+    });
+    it('rounds to 0 when quotient is 0', () => {
+      expect(up(0, 5, calculator)).toBe(0);
+    });
+    it('rounds to -0 with amount -1 and a negative quotient below half that is close to 0', () => {
+      expect(up(-1, 5, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative half quotient that is close to 0', () => {
+      expect(up(-3, 6, calculator)).toBe(-0);
+    });
+    it('rounds to -0 with a negative quotient above half that is close to 0', () => {
+      expect(up(-3, 5, calculator)).toBe(-0);
     });
   });
 });

--- a/packages/core/src/divide/down.ts
+++ b/packages/core/src/divide/down.ts
@@ -1,14 +1,16 @@
 import type { DivideOperation } from '..';
-import { greaterThanOrEqual } from '../utils';
+import { equal, greaterThanOrEqual } from '../utils';
 
 export const down: DivideOperation = (amount, factor, calculator) => {
   const greaterThanOrEqualFn = greaterThanOrEqual(calculator);
+  const equalFn = equal(calculator);
 
   const zero = calculator.zero();
   const isPositive = greaterThanOrEqualFn(amount, zero);
   const quotient = calculator.integerDivide(amount, factor);
+  const remainder = calculator.modulo(amount, factor);
 
-  if (isPositive) {
+  if (isPositive || equalFn(remainder, zero)) {
     return quotient;
   }
 

--- a/packages/core/src/divide/halfUp.ts
+++ b/packages/core/src/divide/halfUp.ts
@@ -1,5 +1,5 @@
 import type { DivideOperation } from '..';
-import { greaterThan, isHalf, absolute } from '../utils';
+import { absolute, greaterThan, isHalf } from '../utils';
 
 import { down, up } from '.';
 
@@ -12,12 +12,20 @@ export const halfUp: DivideOperation = (amount, factor, calculator) => {
   const remainder = absoluteFn(calculator.modulo(amount, factor));
   const difference = calculator.subtract(factor, remainder);
   const isLessThanHalf = greaterThanFn(difference, remainder);
-  const isPositive = greaterThanFn(amount, calculator.increment(zero));
+  const isPositive = greaterThanFn(amount, zero);
+
+  // Round up in these three cases:
+  // (1) the quotient is half:
+  //   e.g. ... -2.5,  -1.5,  -0.5,  0.5,  1.5,  2.5 ...
+  // (2) the quotient is positive, and greater than half:
+  //   e.g.                          0.51, 1.51, 2.51 ...
+  // (3) the quotient is negative, and less than half:
+  //   e.g. ... -2.49, -1.49, -0.49
 
   if (
     isHalfFn(amount, factor) ||
-    (isLessThanHalf && !isPositive) ||
-    (!isLessThanHalf && isPositive)
+    (isPositive && !isLessThanHalf) ||
+    (!isPositive && isLessThanHalf)
   ) {
     return up(amount, factor, calculator);
   }

--- a/packages/core/src/divide/up.ts
+++ b/packages/core/src/divide/up.ts
@@ -1,14 +1,16 @@
 import type { DivideOperation } from '..';
-import { greaterThanOrEqual } from '../utils';
+import { equal, greaterThan } from '../utils';
 
 export const up: DivideOperation = (amount, factor, calculator) => {
-  const greaterThanOrEqualFn = greaterThanOrEqual(calculator);
+  const greaterThanFn = greaterThan(calculator);
+  const equalFn = equal(calculator);
 
   const zero = calculator.zero();
-  const isPositive = greaterThanOrEqualFn(amount, zero);
+  const isPositive = greaterThanFn(amount, zero);
   const quotient = calculator.integerDivide(amount, factor);
+  const remainder = calculator.modulo(amount, factor);
 
-  if (isPositive) {
+  if (!equalFn(remainder, zero) && isPositive) {
     return calculator.increment(quotient);
   }
 


### PR DESCRIPTION
…g of integer results

up/down - Functions should not round integer results.

up - up should only round positive numbers, 0 is not a positive number.

halfUp - halfUp was incorrectly rounding numbers in the [0,1) range due to the incorrect definition of isPositive.

Fixes #710